### PR TITLE
[fix] deprecation warning on didInitAttrs

### DIFF
--- a/addon/mixins/lazy-image.js
+++ b/addon/mixins/lazy-image.js
@@ -26,7 +26,7 @@ export default Mixin.create({
     this._setupAttributes();
   }),
 
-  handleImageUrl: on('didInitAttrs', function() {
+  handleImageUrl: on('init', function() {
     this._setImageUrl();
   }),
 


### PR DESCRIPTION
prefer `on('init')` over `on('didInitAttrs')` https://deprecations-app-prod.herokuapp.com/deprecations/v2.x/#toc_ember-component-didinitattrs